### PR TITLE
Restructure primaryKey to conform with JSON Table Schema

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -289,13 +289,19 @@ Each `field` is a property on the dimension - think of it as column on that dime
 }
 ```
 
-A dimension MUST have at least one field with the property `primaryKey` set on it e.g.
+A dimension MUST have a `primaryKey` property. The property MUST be either an array of strings corresponding to the `fields` hash properties or a single string corresponding to one of the `fields` hash properties. The value of `primaryKey` indicates the primary key or primary keys for the dimension. An example:
 
 ```
-"field-1": {
-  # note being true is optional it can just be set to ""
-  "primaryKey": true
-  "source": "..."
+"dimension-name": {
+  "fields": {
+    "field-1": {
+      "source": "..."
+    },
+    "field-2": {
+      "source": "..."
+    }
+  },
+  "primaryKey": ["field-1"]
 }
 ```
 


### PR DESCRIPTION
Instead of having primaryKey as an empty string or a boolean on a
particular field, the primary key should be a property in and of
itself. This separates concerns within the dimension (primary key
is about the dimension not the field declaration), makes it
correspond to the JSON Table Schema convention (why do it in a
different way?), makes it easier to access and makes it possible
to create a schema.