### PR TITLE
Add dimensionType to examples per #47

### DIFF
--- a/examples/entities-denormalized/datapackage.json
+++ b/examples/entities-denormalized/datapackage.json
@@ -49,6 +49,7 @@
     "dimensions": [
       {
         "name": "date",
+        "dimensionType": "datetime",
         "fields": [
           {
             "name": "year",
@@ -58,6 +59,7 @@
       },
       {
         "name": "payee",
+        "dimensionType": "entity",
         "fields": [
           {
             "name": "id",
@@ -72,6 +74,7 @@
       }
       {
         "name": "payor",
+        "dimensionType": "entity",
         "fields": [
           {
             "name": "id",

--- a/examples/entities-normalized/datapackage.json
+++ b/examples/entities-normalized/datapackage.json
@@ -78,6 +78,7 @@
     "dimensions": [
       {
         "name": "date",
+        "dimensionType": "datetime",
         "fields": [
           {
             "name": "year",
@@ -87,6 +88,7 @@
       },
       {
         "name": "payee",
+        "dimensionType": "entity",
         "fields": [
           {
             "name": "id",


### PR DESCRIPTION
Given that dimensionType is optional, I have skipped the minimal
example.