### PR TITLE
Huge simplification and tighten-up of the "Content" section, 

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -369,7 +369,7 @@ This section provides guidance, and certain requirements, on the naming of dimen
 Dimensions of type `classification` with these names are significant:
 
 * `"cofog"`: the United Nations [Classification of the Functions of Government][cofog]
-* `"gfsm"`: the[IMF Government Finance Statistics Manual (2014)][gfsm2014]. For expenditure classification, use Table 6.1. For revenue, use Table 5.1.
+* `"gfsm"`: the [IMF Government Finance Statistics Manual (2014)][gfsm2014]. For expenditure classification, use Table 6.1. For revenue, use Table 5.1.
 
 [gfsm2014]: http://www.imf.org/external/np/sta/gfsm/
 
@@ -389,7 +389,7 @@ A `dimensionType` of `activity` defines the program or project associated with e
   "dimensionType": "activity",
   "attributes": {
     // Attributes SHOULD be named as follows, if available:    
-    "id": { .. },    // The internal code identifier for the government program or project
+    "id": { ... },    // The internal code identifier for the government program or project
     "title": { ... } // Name of the government program or project underwriting the budget item.
   }
 }
@@ -405,9 +405,9 @@ A `dimensionType` of `entity` is describes a distinct organization, government d
 
   "attributes": {
     // Attributes SHOULD be named as follows, if available:
-    "title": {...},        // The title or name of the government entity legally responsible for spending the budgeted amount.
-    "id": {...},           // The internal code for the administrative entity.
-    "location": {...}      // Reference to a dimension of type `location` providing the geographical region where the administrative entity is located.
+    "title": { ... },        // The title or name of the government entity legally responsible for spending the budgeted amount.
+    "id": { ... },           // The internal code for the administrative entity.
+    "location": { ... }      // Reference to a dimension of type `location` providing the geographical region where the administrative entity is located.
   }
 }
 ```
@@ -428,9 +428,9 @@ A `dimensionType` of `location` defines the geographic region associated with an
   "dimensionType": "location",
   "attributes": {
     // Attributes SHOULD be named as follows, if available:
-    "code": {...},    // A code uniquely identifying the geographic region.
-    "title": {...},   // The title of the geographic region.
-    "codeList": {...} // The name of the standard or list which the codes belong to. No standard way to refer to them is given.
+    "code": { ... },    // A code uniquely identifying the geographic region.
+    "title": { ... },   // The title of the geographic region.
+    "codeList": { ... } // The name of the standard or list which the codes belong to. No standard way to refer to them is given.
   }
 }
 ```

--- a/spec/index.md
+++ b/spec/index.md
@@ -259,9 +259,8 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
 ```javascript
 "dimensions": {
   "project-class": {
-    // REQUIRED: An attributes object that defines the attributes of the 
-    // dimension. Think of each attribute as a column on that dimension in 
-    // a database. Each attribute MUST have `source` information - 
+    // REQUIRED: An attributes object listing the one or more columns that make up
+    // the dimension. Each attribute MUST have `source` information - 
     // i.e. where the data comes from for that property 
     "attributes": {
       "project": {
@@ -286,7 +285,7 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
         "labelfor": "..."
       },
 
-      // Other attributes may be REQUIRED, depending on the dimensionType. See the "Dimension types" section.
+      // Other attributes may be required, depending on the dimensionType. See the "Dimension types" section.
       "code": {
         "source": "class_code"
       }
@@ -347,12 +346,14 @@ This section provides guidance, and certain requirements, on the naming of dimen
   "classificationType": "administrative",
 
   "attributes": {
-    // REQUIRED: a "code" column containing unique identifiers from an official codesheet. If classifications are subject to change, a `version` attribute `SHOULD` be used. 
+    // REQUIRED: a "code" attribute, referencing a column whose values are unique identifiers from the relevant codesheet (see "Known classification schemes").
     "code": {
       "source": "PROJECT_CODE",
       // To define a hierarchical classification, the "parent" attribute refers to the attribute "above" it in the hierarchy.
       // Set it on the `code` field, not a title field. See the ["Labels and Hierarchies" example][/examples/labels-and-hierarchies/].
       "parent": "PROGRAMME_NAME"
+      // Optional: If classifications are subject to change, a `version` attribute `SHOULD` be used. 
+      // "version": "1.3"
     },
     "program": {
       "source": "PROGRAMME_NAME"
@@ -361,6 +362,7 @@ This section provides guidance, and certain requirements, on the naming of dimen
       "source": "PROJECT_NAME"
     }
   }
+  // (primary key and other properties are omitted in this section)
 }
 ```
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -344,7 +344,7 @@ This section provides guidance, and certain requirements, on the naming of dimen
   //   Health > Hospital services > Nursing
   // * "economic": focused on the nature of the accounting, such 
   //   as Compensation > Wages and salaries > Wages and salaries in cash
-  "classificationType": "administrative"
+  "classificationType": "administrative",
 
   "attributes": {
     // REQUIRED: a "code" column containing unique identifiers from an official codesheet. If classifications are subject to change, a `version` attribute `SHOULD` be used. 
@@ -357,9 +357,10 @@ This section provides guidance, and certain requirements, on the naming of dimen
     "program": {
       "source": "PROGRAMME_NAME"
     },
-    "project": "{
+    "project": {
       "source": "PROJECT_NAME"
     }
+  }
 }
 ```
 
@@ -406,7 +407,7 @@ A `dimensionType` of `entity` is describes a distinct organization, government d
     // Attributes SHOULD be named as follows, if available:
     "title": {...},        // The title or name of the government entity legally responsible for spending the budgeted amount.
     "id": {...},           // The internal code for the administrative entity.
-    "location": {...},     // Reference to a dimension of type `location` providing the geographical region where the administrative entity is located.
+    "location": {...}      // Reference to a dimension of type `location` providing the geographical region where the administrative entity is located.
   }
 }
 ```

--- a/spec/index.md
+++ b/spec/index.md
@@ -8,6 +8,7 @@ author:
  - Tryggvi Björgvinsson (Open Knowledge)
  - Rufus Pollock (Open Knowledge)
  - Paul Walsh (Open Knowledge)
+ - Steve Bennett (Open Knowledge Australia)
 summary: Fiscal Data Package is a lightweight and user-oriented format for publishing and consuming fiscal data. Fiscal data packages are made of simple and universal components. They can be produced from ordinary spreadsheet software and used in any environment.
 ---
 
@@ -260,7 +261,7 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
   "project-class": {
     // REQUIRED: An attributes object that defines the attributes of the 
     // dimension. Think of each attribute as a column on that dimension in 
-    // a database. An attribute MUST have `source` information - 
+    // a database. Each attribute MUST have `source` information - 
     // i.e. where the data comes from for that property 
     "attributes": {
       "project": {
@@ -284,6 +285,8 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
         // pointing to "project_code"
         "labelfor": "..."
       },
+
+      // Other attributes may be REQUIRED, depending on the dimensionType. See the "Dimension types" section.
       "code": {
         "source": "class_code"
       }
@@ -313,20 +316,7 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
     //   attached to a transaction
     // * "location": the geographical location where money is spent
     // * "other": not one of the above
-    "dimensionType": "classification",
-
-    // RECOMMENDED (if using dimensionType="classification"). The 
-    // basis on which transactions are being classified, one of 
-    // these values:
-    //
-    // * "administrative": an organisational structure, such as 
-    //   Portfolio > Department > Branch
-    // * "functional": the purpose of the spending, such as 
-    //   Health > Hospital services > Nursing
-    // * "economic": focused on the nature of the accounting, such 
-    //   as Compensation > Wages and salaries > Wages and salaries 
-    //   in cash
-    "classificationType": "administrative"
+    "dimensionType": "classification"
 
     // OPTIONAL: Other properties allowed.
 
@@ -335,7 +325,119 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
 }
 ```
 
-## Examples
+
+# Dimension types
+
+This section provides guidance, and certain requirements, on the naming of dimension attributes. For example, if you have a column representing the name of an organisation, it should be modelled as a `title` attribute on an dimension with `dimensionType` of `entity`.
+
+## Classification
+
+```javascript
+"spending-classification": {
+  "dimensionType": "classification",
+
+  // RECOMMENDED: The basis on which transactions are being classified, one of these values:
+  //
+  // * "administrative": an organisational structure, such as 
+  //   Portfolio > Department > Branch
+  // * "functional": the purpose of the spending, such as 
+  //   Health > Hospital services > Nursing
+  // * "economic": focused on the nature of the accounting, such 
+  //   as Compensation > Wages and salaries > Wages and salaries in cash
+  "classificationType": "administrative"
+
+  "attributes": {
+    // REQUIRED: a "code" column containing unique identifiers from an official codesheet. If classifications are subject to change, a `version` attribute `SHOULD` be used. 
+    "code": {
+      "source": "PROJECT_CODE",
+      // To define a hierarchical classification, the "parent" attribute refers to the attribute "above" it in the hierarchy.
+      // Set it on the `code` field, not a title field. See the ["Labels and Hierarchies" example][/examples/labels-and-hierarchies/].
+      "parent": "PROGRAMME_NAME"
+    },
+    "program": {
+      "source": "PROGRAMME_NAME"
+    },
+    "project": "{
+      "source": "PROJECT_NAME"
+    }
+}
+```
+
+### Known classification schemes
+
+Dimensions of type `classification` with these names are significant:
+
+* `"cofog"`: the United Nations [Classification of the Functions of Government][cofog]
+* `"gfsm"`: the[IMF Government Finance Statistics Manual (2014)][gfsm2014]. For expenditure classification, use Table 6.1. For revenue, use Table 5.1.
+
+[gfsm2014]: http://www.imf.org/external/np/sta/gfsm/
+
+### Chart of Accounts
+
+To describe an "economic" classification for an item using the publisher's chart of accounts, use these attributes:
+
+* `code`:  The internal code identifier for the economic classification.
+* `title`:  Human-readable name of the economic classification of the budget item (i.e. the type of expenditure, e.g. purchases of goods, personnel expenses, etc.), drawn from the publisher's chart of accounts.
+
+## Activity
+
+A `dimensionType` of `activity` defines the program or project associated with expenditure or revenue. When these terms are not used interchangably, the distinction is generally that "programs" (a sets of goal-oriented activities) contain "projects" (specific sets of tasks with a defined budget and schedule).
+
+```javascript
+"program-or-project-name": {
+  "dimensionType": "activity",
+  "attributes": {
+    // Attributes SHOULD be named as follows, if available:    
+    "id": { .. },    // The internal code identifier for the government program or project
+    "title": { ... } // Name of the government program or project underwriting the budget item.
+  }
+}
+```
+
+## Entity
+
+A `dimensionType` of `entity` is describes a distinct organization, government department, or individual that is spending or receiving a given amount.
+
+```javascript
+"program-or-project-name": {
+  "dimensionType": "entity",
+
+  "attributes": {
+    // Attributes SHOULD be named as follows, if available:
+    "title": {...},        // The title or name of the government entity legally responsible for spending the budgeted amount.
+    "id": {...},           // The internal code for the administrative entity.
+    "location": {...},     // Reference to a dimension of type `location` providing the geographical region where the administrative entity is located.
+  }
+}
+```
+
+### Accounts as entities
+
+Although an "account" through which money is spent or received is not strictly an "entity", it can be treated as one for analysis as follows:
+
+* `title`: The fund into which the revenue item will be deposited. (This refers to a named revenue stream.)
+* `id`: The internal code identifier for the fund.
+
+## Location
+
+A `dimensionType` of `location` defines the geographic region associated with an item of expenditure or revenue, enabling spatial analysis.
+
+```javascript
+"projectlocation": {
+  "dimensionType": "location",
+  "attributes": {
+    // Attributes SHOULD be named as follows, if available:
+    "code": {...},    // A code uniquely identifying the geographic region.
+    "title": {...},   // The title of the geographic region.
+    "codeList": {...} // The name of the standard or list which the codes belong to. No standard way to refer to them is given.
+  }
+}
+```
+
+(An alternative option is to add `geoCode`, `geoTitle` and/or `geoCodeList` attributes directly to another dimension.)
+
+----
+# Examples
 
 {% assign sorted_pages = site.pages | sort:"order" %}
 {% for page in sorted_pages %}
@@ -344,154 +446,10 @@ Each dimension is represented by a key in the `dimensions` object. The object ha
   {% endif %}
 {% endfor %}
 
-# Content
-
-This section provides a standard framework for the "content" of Fiscal Data Packages. The previous section has been about the form both for the data (e.g. that it is CSV) and for the metadata (the information in the datapackage.json). This section is about the "content", that is the kind of actual data a Package contains. In particular, it sets out guidelines for what information, exactly, is present. For example, that government budget information is classified according to a standard classification codesheet like the [UN's COFOG][cofog].
-
-[cofog]: http://data.okfn.org/data/core/cofog/
-
-Content requirements will necessarily vary across the different types of fiscal data. For example, the data describing high level budgets may be different from that describing day-to-day expenditures, and expenditure information may be different from revenue. Thus, our framework will distinguish different types of fiscal data.
-
-We also emphasize that what we provide is a framework rather than a strict standard. That is, we provide recommendations on what information should be provided rather than strict requirements.
-
-Finally, our recommendations place requirements on the "logical" model not the physical model. Of course, the logical model data is sourced from the physical model so requirements on the logical model ultimately place requirements on the physical model. However, by defining our requirements on the logical model, we keep the flexibility in naming and structure of the raw, source data - for example, whilst a classification dimension with COFOG data should be named `cofog` and have an attribute called `code` your source CSV could have that COFOG data in a column called "COFOG-Code" or "Classification" or any other name.
-
-
-## Required data (all categories)
-
-All datasets MUST have at least one measure. Essentially this is requiring each dataset have at least one field / column which corresponds to an "amount" of money.
-
-## Special Dimensions
-
-### Classifications
-
-It is common for fiscal data to be classified in various ways. A classification is a labelling of a given item with a reference to standardized codesheet.
-
-Classifications will be represented in the model as a dimension. Each classification dimension `MUST` have a `code` attribute whose value will correspond to the classification code in the official codesheet. Sometimes classifications can change and we recommend utilizing a `version` attribute if there is a need to indicate the version of a classification.
-
-Whenever we have a code attribute in a classification dimension, the licit values for that attribute consist of the numerical codes from the appropriate codesheet, with hierarchical levels separated by periods. `1.1.4.1.3` is a licit value for a dimension named `gfsm`, for example, corresponding to the code for "Turnover and other general taxes on goods and services".
-
-Classifications are of different types. The type of the classification `MAY` be indicated using the `classificationType` attribute on the dimension. Values are:
-
-* `functional`
-* `administrative`
-* `economic`
-
-#### Hierarchical Classifications
-
-It is common for classifications to be hierarchical and have different levels. For example, a functional classification might include a top-level of "Healthcare" and a sub-level under "Healthcare" of "Hospitals".
-
-This hierarchical structure of the classification can be recorded using the keyword `parent`.  The `parent` keyword is used within an attribute definition to reference another attribute in the same dimension that is the parent of the first attribute. Here is an example:
-
-```
-"your-classification": {
-  "attributes": {
-    "code": {
-      // this will be the precise code
-      "source": "..."
-    },
-    "level1": {
-      "source": "..."
-    },
-    "level2": "{
-      "source": "...",
-      "parent": "level1"
-    }
-  }
-}
-```
-
-Sometimes matters may be more complex. For example, there may be several attributes that describe a level e.g. "Hospital" may also have a code such as "01". In this case you only use the `parent` key on the attribute that acts as the unique code or identifier for a given level. For an example, as well as further information on handling hierarchical classifications see the ["Labels and Hierarchies" example][ex-hierarchies].
-
-[ex-hierarchies]: /examples/labels-and-hierarchies/
-
-#### COFOG (Classifications of Functions of Government)
-
-This classification uses the United Nations [Classification of the Functions of Government][cofog]. Here is the simplest example as a dimension:
-
-```
-"cofog": {
-  "attributes": {
-    "code": {
-      "source": "..."
-    }
-  }
-}
-```
-
-#### IMF GFSM
-
-GFSM is the [IMF Government Finance Statistics Manual (2014)][gfsm2014]. For expenditure classification, use Table 6.1. For revenue, use Table 5.1.
-
-[gfsm2014]: http://www.imf.org/external/np/sta/gfsm/
-
-#### Chart of Accounts
-
-It is common for both revenue and expenditure that there is some general "economic" classification for the item using the publisher's chart of accounts. Relevant attributes for this dimension:
-
-* `code`:  The internal code identifier for the economic classification.
-* `title`:  Human-readable name of the economic classification of the budget item (i.e. the type of expenditure, e.g. purchases of goods, personnel expenses, etc.), drawn from the publisher's chart of accounts.
-
-### Programs and Projects
-
-Expenditures are frequently associated with a program or project. Often these terms are used interchangeably. There is a rough distinction:
-
-* Program: A program is a set of goal-oriented activities, such as projects, that has been reified by the government and made the responsibility of some ministry. A program can, e.g. be a government commitment to reducing unemployment.
-* Project: A project is an indivisible activity with a dedicated budget and fixed schedule. A project can be a part of a bigger program and can include multiple smaller tasks. A project in an unemployment reduction program can e.g. be increased education opportunities for adults.
-
-In terms of representation as a dimension, we use a `dimensionType` of "activity".  The structure is as follows:
-
-```
-"program-or-project-name": {
-  "dimensionType": "activity",
-  "attributes": {
-    "id": {
-      # The internal code identifier for the government program or project
-
-      "source": ...
-    },
-    "title": {
-      # Name of the government program or project underwriting the budget item.
-
-      "source": ...
-    }
-  }
-}
-```
-
-### Entities
-
-An entity is a distinct organization, government department, or individual that is spending or receiving a given amount.  Entities will be represented by dimensions.
-
-#### Administrators
-
-* `title`: The title or name of the government entity legally responsible for spending the budgeted amount.
-* `id`: The internal code for the administrative entity.
-* `location`: Reference to a `location` dimension listing geographical region where administrative entity is located.
-* `locationCode`: code for geographical region where administrative entity is located.
-
-#### Accounts
-
-Whilst strictly not an entity, the concept of an "account" from which money is spent or into which money is deposited is common and closely resembles an "entity" in terms of functionality within fiscal analysis (e.g. tracing the movement of money between different pots). Recommended attributes on an account dimension are:
-
-* `title`: The fund into which the revenue item will be deposited. (This refers to a named revenue stream.)
-* `id`: The internal code identifier for the fund.
-
-### Location
-
-There is a frequent desire to label items with location, usually by attaching geographic codes for a region or area. This allows the spending or revenue to  be analysed by region or area. This geographic information can be introduced directly by classifying the item with a code, or, more frequently indirectly by associating a geographic code to e.g. an entity. For example, by labelling a supplier with their location one can then associate a spend with that supplier as spending in that location.
-
-We RECOMMEND using a `location` dimension though attributes may also be applied directly onto another object (e.g. an entity). Here are attributes that `MAY` be applied either directly to an item or to an entity or other object associated to an item.
-
-* `code`: The internal or local geographicCode id based for the geographical region
-* `title`: Name or title of the geographical region targeted by the budget item
-* `codeList`: the geo codelist from which the geocode is drawn 
-
-Note when applying these as attributes directly on an object we suggest prefixing each value with `geo` so you would have `geoCode` rather than `code` etc.
 
 ----
 
-## Suggested Dimensions for Different Types of Spending Data
+## Which dimension type?
 
 This section lists the suggested sets of dimensions that can usefully describe different types of spending data.  
 


### PR DESCRIPTION
which is now renamed "Dimension types". Removed a lot of chatter, replacing it with
specific guidance in commented JSON format.

One thing I noticed is that there are a couple of underspecified recommendations:

- how exactly should codelist versions be specified
- how should location codelists be referred to?